### PR TITLE
MovingObject

### DIFF
--- a/bounce/game.py
+++ b/bounce/game.py
@@ -87,8 +87,9 @@ class Game(State):
                 self.player.append_bullet(event, self.gameboard)
                 self.player.move_bullets(self.gameboard, 12)
 
-                self.check_bullets_game_objects_collision(self.gameboard.collectables)
-                self.check_bullets_game_objects_collision(self.gameboard.obstacles)
+                # FIXME: replace these methods with the `on_collision` event handlers
+                # self.check_bullets_game_objects_collision(self.gameboard.collectables)
+                # self.check_bullets_game_objects_collision(self.gameboard.obstacles)
 
                 self.update_scores()
 

--- a/bounce/game.py
+++ b/bounce/game.py
@@ -82,7 +82,8 @@ class Game(State):
                 self.camera.adjust(screen, self.player)
 
                 # update player and its bullets positions
-                self.player.move(screen, event, self.gameboard)
+                self.player.process_event(event)
+                self.player.move(self.gameboard)
                 self.player.append_bullet(event, self.gameboard)
                 self.player.move_bullets(self.gameboard, 12)
 

--- a/bounce/game_object.py
+++ b/bounce/game_object.py
@@ -19,7 +19,7 @@ class GameObject(pygame.sprite.Sprite):
         distance = other_rect.distance_y(self.rect)
         return distance != inf and distance > 0
     
-    def is_over(self, other_rect):
+    def is_above(self, other_rect):
         """
         Checks if `self` is located over `other_rect`, regardless of the distance
         """

--- a/bounce/gameboard.py
+++ b/bounce/gameboard.py
@@ -10,6 +10,37 @@ class GameBoard:
         self.obstacles = obstacles
         self.bullets = bullets
 
+    def all_objects(self):
+        return self.walls + self.collectables + self.obstacles + self.bullets
+
+    def objects_under(self, player):
+        return [
+            obj
+            for obj in self.all_objects()
+            if obj.is_under(player.rect)
+        ]
+
+    def objects_above(self, player):
+        return [
+            obj
+            for obj in self.all_objects()
+            if obj.is_above(player.rect)
+        ]
+
+    def objects_left(self, player):
+        return [
+            obj
+            for obj in self.all_objects()
+            if obj.is_to_the_left(player.rect)
+        ]
+
+    def objects_right(self, player):
+        return [
+            obj
+            for obj in self.all_objects()
+            if obj.is_to_the_right(player.rect)
+        ]
+
     def walls_under(self, player):
         """
         All the walls currently positioned under the player
@@ -19,7 +50,6 @@ class GameBoard:
             for wall in self.walls
             if wall.is_under(player.rect)]
         return ans
-
 
     def walls_right(self, player):
         """

--- a/bounce/moving_object.py
+++ b/bounce/moving_object.py
@@ -1,0 +1,96 @@
+from silnik.rendering.point import Point
+
+from .game_object import GameObject
+
+class MovingObject(GameObject):
+    """
+    Base class for all `GameObjects` that may move.
+
+    Implements logic related to displacement and a priori
+    collision detection.
+    """
+
+    # gravity parameter used for relating jumping velocity to main velocity G * v
+    G = 0  # set to 0 for now -> update to a positive value after implementing horizontal walls
+
+    def __init__(self, image, x=0, y=0, v_x0=0, v_y0=0, m=0, speed_unit=1):
+        # TODO: wrap these parameters in an object / class
+        super().__init__(image=image, x=x, y=y)
+
+        self.speed_unit = speed_unit
+        self.v_x = v_x0
+        self.v_y = v_y0
+        self.m = m
+
+    def is_mid_air(self):
+        return self.v_y != 0
+
+    def is_jumping(self):
+        return self.v_y < 0
+
+    def is_falling(self):
+        return self.v_y > 0
+
+    def is_mid_x(self):
+        return self.is_moving_left() or self.is_moving_right()
+
+    def is_moving_right(self):
+        return self.v_x > 0
+
+    def is_moving_left(self):
+        return self.v_x < 0
+
+    def call_movement_functions(self, gameboard):
+        self.move_x(gameboard)
+        self.move_y(gameboard)
+
+    def move_x(self, gameboard):
+        # find x position of the closest obstacle edges on the right and left side of the player
+        limit_right = gameboard.limit_right(self)
+        limit_left = gameboard.limit_left(self)
+
+        # stop movement if collision on either side of the player takes place
+        if self.is_moving_right() and self.v_x > limit_right:
+            wall = self.rect.right + limit_right
+            self.on_collision(
+                location=Point(wall, self.rect.y),
+                direction='R')
+        
+        elif self.is_moving_left() and self.v_x < limit_left:
+            wall = self.rect.left + limit_left
+            self.on_collision(
+                location=Point(wall, self.rect.y),
+                direction='L')
+        
+        else:
+            # Free movement -> update the position based on the speed
+            self.rect.x += self.v_x
+
+    def move_y(self, gameboard):
+        limit = gameboard.limit_under(self)
+
+        # Calculate y-acceleration (gravity pull)
+        a = self.m * self.G
+
+        # Update y-speed with new acceleration
+        self.v_y += a
+
+        will_hit_floor = self.v_y > limit
+
+        if will_hit_floor:
+            floor = self.rect.bottom + limit
+            self.on_collision(
+                location=Point(self.rect.x, floor),
+                direction='U')
+        else:
+            # Update y-position
+            self.rect.y += self.v_y
+
+    def on_collision(self, location, direction, object_hit=None):
+        # TODO: refactor move_x/y a bit to get a reference to the
+        # colliding object (the `object_hit` variable) and the
+        # proper location (the current one is an approximation)
+        message = "{} needs to implement the `on_collision` method!".format(
+            self.__class__.__name__)
+
+        raise NotImplementedError(message)

--- a/bounce/player.py
+++ b/bounce/player.py
@@ -1,69 +1,45 @@
 import pygame
-from pygame.locals import *
-from .game_object import *
-from .moving_object import MovingObject
 
 from silnik import image
 from silnik.rendering.shape import Polygon, rectangle
 from silnik.rendering.point import Point
 
-from .constants import *
+from .game_object import GameObject
+from .moving_object import MovingObject
+from .constants import Colors, CONTROLS
 from . import image_paths
 
 
 class Player(MovingObject):
 
-    # factor used to calculate max jump height, used to multiply player's speed unit
-    LEAP_FORCE = 5
-
     def __init__(self, speed_unit=1):
         img = image.Image.load(image_paths.PLAYER_MAIN)
-        super().__init__(image=img, speed_unit=speed_unit)
+        super().__init__(image=img, speed_unit=speed_unit, v_x0=-speed_unit, v_y0=-speed_unit/3, m=4)
 
-        # acceleration, velocity, mass - used for acceleration and deceleration. 
-        # separate velocities for movement on x axis (right/left) and y axis (jump)
-        self.v_x = 0
-        self.v_y = - self.speed_unit/3
-        self.m = 4
-
-        # initial direction - to the left
-        self.direction = 'L'
+        self.store_last_movement_direction()
 
     def is_crashed(self):
         return (self.rect.left < 50 or self.rect.right > 600)
 
-    # handle user input
-    # TODO: rename this method
-    def move(self, screen, event, gameboard):
-        
-        keystate = pygame.key.get_pressed()
+    def process_event(self, event):
 
-        if not self.is_mid_x():
+        if event.type == pygame.KEYDOWN and not self.is_mid_x():
 
-            ## here need to change to also use the dictionary CONTROLS - tbd later
-            #if (keystate[K_RIGHT] or keystate[K_d]):
-
-            if event.type == pygame.KEYDOWN:
-
-                if event.key in CONTROLS["G_RIGHT"]:
-                    self.direction = 'R'
-                    self.v_x = self.speed_unit
-
-                if event.key in CONTROLS["G_LEFT"]:
-                    self.direction = 'L'
-                    self.v_x = - self.speed_unit
-
-
-            # fall to the right/left if obstacle's end is reached
-            # FIXME: commented out because `gameboard` implementation is not yet ready
-            if self.direction == 'R' and  not gameboard.is_colliding_wall_right(self):
+            if event.key in CONTROLS["G_RIGHT"]:
                 self.v_x = self.speed_unit
 
-            if self.direction == 'L' and not gameboard.is_colliding_wall_left(self):
+            elif event.key in CONTROLS["G_LEFT"]:
                 self.v_x = - self.speed_unit
 
+    def move(self, gameboard):
+        self.store_last_movement_direction()
 
-        # call movement functions after handling user input
+        if self._last_movement_direction == 'R' and  not gameboard.is_colliding_wall_right(self):
+            self.v_x = self.speed_unit
+
+        elif self._last_movement_direction == 'L' and not gameboard.is_colliding_wall_left(self):
+            self.v_x = -self.speed_unit
+
         self.call_movement_functions(gameboard)
         self.handle_images()
 
@@ -77,9 +53,6 @@ class Player(MovingObject):
         elif direction == 'R':
             self.stop_movement_x(location.x - self.rect.width)
 
-    def jump(self):
-        self.v_y = -self.speed_unit * self.LEAP_FORCE
-
     def stop_movement_x(self, x):
         self.rect.x = x
         self.v_x = 0
@@ -89,8 +62,6 @@ class Player(MovingObject):
         self.v_y = 0
 
     def handle_images(self):
-
-        #if self.is_mid_x():
         if self.is_crashed():
             img = image_paths.PLAYER_CRASH
         
@@ -124,5 +95,14 @@ class Player(MovingObject):
             y = y)
 
     def move_bullets(self, gameboard, bullet_speed):
+        # TODO: create a `Bullet` class, derive from `MovingObject`, let it handle its own movement
         for bullet in gameboard.bullets:
             bullet.rect.y -= bullet_speed
+
+    def store_last_movement_direction(self):
+        # don't update if `self` is not currently moving
+        if self.v_x == 0:
+            pass
+        else:
+            direction = 'L' if self.v_x < 0 else 'R'
+            self._last_movement_direction = direction

--- a/bounce/player.py
+++ b/bounce/player.py
@@ -19,6 +19,7 @@ class Player(MovingObject):
         self.store_last_movement_direction()
 
     def is_crashed(self):
+        return False
         return (self.rect.left < 50 or self.rect.right > 600)
 
     def process_event(self, event):
@@ -34,7 +35,7 @@ class Player(MovingObject):
     def move(self, gameboard):
         self.store_last_movement_direction()
 
-        if self._last_movement_direction == 'R' and  not gameboard.is_colliding_wall_right(self):
+        if self._last_movement_direction == 'R' and not gameboard.is_colliding_wall_right(self):
             self.v_x = self.speed_unit
 
         elif self._last_movement_direction == 'L' and not gameboard.is_colliding_wall_left(self):
@@ -43,15 +44,25 @@ class Player(MovingObject):
         self.call_movement_functions(gameboard)
         self.handle_images()
 
-    def on_collision(self, location, direction, object_hit=None):
-        if direction == 'U':
-            self.stop_movement_y(location.y)
-        elif direction == 'D':
-            self.stop_movement_y(location.y - self.rect.height)
-        elif direction == 'L':
-            self.stop_movement_x(location.x)
-        elif direction == 'R':
-            self.stop_movement_x(location.x - self.rect.width)
+    def on_collision_y(self, object_hit):
+        distance = self.rect.distance_y(object_hit.rect)
+        location = self.rect.y + distance
+        
+        if distance < 0:  # player must've been going down
+            # TODO: self.stop_movement_y(location + 1), remove the object
+            pass
+        else:
+            # TODO: self.stop_movement_y(location - 1), remove the object
+            pass
+
+    def on_collision_x(self, object_hit):
+        distance = self.rect.distance_x(object_hit.rect)
+        location = self.rect.x + distance
+
+        if distance < 0:  # player must've been going left
+            self.stop_movement_x(location + 1)
+        else:
+            self.stop_movement_x(location- 1)
 
     def stop_movement_x(self, x):
         self.rect.x = x

--- a/tests/test_game_object.py
+++ b/tests/test_game_object.py
@@ -46,18 +46,18 @@ class TestIsUnder(TestGameObject):
         self.assertFalse(
             self.object.is_under(self.rect_left))
 
-class TestIsOver(TestGameObject):
+class TestIsAbove(TestGameObject):
     def test_is_true_for_rect_below(self):
         self.assertTrue(
-            self.object.is_over(self.rect_below))
+            self.object.is_above(self.rect_below))
 
     def test_is_false_for_rect_above(self):
         self.assertFalse(
-            self.object.is_over(self.rect_above))
+            self.object.is_above(self.rect_above))
 
     def test_is_false_for_rect_on_the_side(self):
         self.assertFalse(
-            self.object.is_over(self.rect_left))
+            self.object.is_above(self.rect_left))
 
 class TestIsToTheRight(TestGameObject):
     def test_is_true_for_rect_on_the_left(self):

--- a/tests/test_game_object.py
+++ b/tests/test_game_object.py
@@ -1,9 +1,8 @@
-import pygame
 from unittest import TestCase
 
-from silnik import image
+from silnik.image import Image
 from silnik.rendering.point import Point
-from silnik.rendering.shape import Polygon
+from silnik.rendering.shape import Polygon, rectangle
 
 from bounce.game_object import GameObject
 from bounce import image_paths
@@ -19,15 +18,16 @@ class TestGameObject(TestCase):
         Resets the state for each test case, which in turn decouples
         tests from each other.
         """
-        size = width, height = (1280, 720)
-        screen = pygame.display.set_mode(size)  # FIXME: decouple GameObject from pygame.display
-        img = image.Image.load(image_paths.PLAYER_MAIN)  # some image is needed to construct an GameObject
-        self.game_object = GameObject(img)
-        self.base_rect = self.game_object.rect
+        shape = rectangle(
+            Point(0, 0),
+            Point(100, 100))
+        img = Image("mock_raw_image", shape)
+        self.object = GameObject(img)
+        self.base_rect = self.object.rect
 
         # Non-overlapping rectangles
-        x_offset = self.game_object.rect.width
-        y_offset = self.game_object.rect.height
+        x_offset = self.object.rect.width
+        y_offset = self.object.rect.height
         self.rect_above = self.base_rect.shifted(y_shift=-(10 + y_offset))
         self.rect_below = self.base_rect.shifted(y_shift=10 + y_offset)
         self.rect_left = self.base_rect.shifted(x_shift=-(10 + x_offset))
@@ -36,46 +36,46 @@ class TestGameObject(TestCase):
 class TestIsUnder(TestGameObject):
     def test_is_under_is_true_for_rect_above(self):
         self.assertTrue(
-            self.game_object.is_under(self.rect_above))
+            self.object.is_under(self.rect_above))
 
     def test_is_under_is_false_for_rect_below(self):
         self.assertFalse(
-            self.game_object.is_under(self.rect_below))
+            self.object.is_under(self.rect_below))
 
     def test_is_under_is_false_for_rect_on_the_side(self):
         self.assertFalse(
-            self.game_object.is_under(self.rect_left))
+            self.object.is_under(self.rect_left))
 
 class TestIsOver(TestGameObject):
     def test_is_true_for_rect_below(self):
         self.assertTrue(
-            self.game_object.is_over(self.rect_below))
+            self.object.is_over(self.rect_below))
 
     def test_is_false_for_rect_above(self):
         self.assertFalse(
-            self.game_object.is_over(self.rect_above))
+            self.object.is_over(self.rect_above))
 
     def test_is_false_for_rect_on_the_side(self):
         self.assertFalse(
-            self.game_object.is_over(self.rect_left))
+            self.object.is_over(self.rect_left))
 
 class TestIsToTheRight(TestGameObject):
     def test_is_true_for_rect_on_the_left(self):
         self.assertTrue(
-            self.game_object.is_to_the_right(self.rect_left))
+            self.object.is_to_the_right(self.rect_left))
 
     def test_is_false_for_rect_on_the_right(self):
         self.assertFalse(
-            self.game_object.is_to_the_right(self.rect_right))
+            self.object.is_to_the_right(self.rect_right))
 
     def test_is_false_for_rect_above(self):
         self.assertFalse(
-            self.game_object.is_to_the_right(self.rect_above))
+            self.object.is_to_the_right(self.rect_above))
 
     def test_is_false_for_line_in_the_bottom_left_corner(self):
         corner = Point(
-            self.game_object.rect.left,
-            self.game_object.rect.bottom)
+            self.object.rect.left,
+            self.object.rect.bottom)
         
         # Build a line so that the player is on its edge
         line = Polygon([
@@ -83,17 +83,17 @@ class TestIsToTheRight(TestGameObject):
             corner + Point(10, 10)])
 
         self.assertFalse(
-            self.game_object.is_to_the_right(line))
+            self.object.is_to_the_right(line))
 
 class TestIsToTheLeft(TestGameObject):
     def test_is_true_for_rect_on_the_right(self):
         self.assertTrue(
-            self.game_object.is_to_the_left(self.rect_right))
+            self.object.is_to_the_left(self.rect_right))
 
     def test_is_false_for_rect_on_the_left(self):
         self.assertFalse(
-            self.game_object.is_to_the_left(self.rect_left))
+            self.object.is_to_the_left(self.rect_left))
 
     def test_is_false_for_rect_above(self):
         self.assertFalse(
-            self.game_object.is_to_the_left(self.rect_above))
+            self.object.is_to_the_left(self.rect_above))

--- a/tests/test_moving_object.py
+++ b/tests/test_moving_object.py
@@ -1,0 +1,62 @@
+import pygame
+from unittest import TestCase, mock
+
+from silnik import image
+from silnik.rendering.point import Point
+
+from bounce.gameboard import GameBoard
+from bounce.game_object import GameObject
+from bounce.moving_object import MovingObject
+from bounce import image_paths
+
+class TestMovingObject(TestCase):
+    """
+    Base TestCase to share the setup logic and data
+    """
+    def setUp(self):
+        size = width, height = (1280, 720)
+        screen = pygame.display.set_mode(size)  # FIXME: decouple GameObject from pygame.display
+        img = image.Image.load(image_paths.PLAYER_MAIN)  # some image is needed to construct an GameObject
+        
+        self.object = MovingObject(img)
+        self.base_rect = self.object.rect
+
+    def make_wall(self, x=0, y=0):
+        img = image.Image.create(self.base_rect.clone())
+        return GameObject(
+            img,
+            x=x + self.base_rect.width,
+            y=y + self.base_rect.height)
+
+class TestMove(TestMovingObject):
+    def setUp(self):
+        super().setUp()
+        self.object.v_x = 100
+
+    def test_updates_x_position(self):
+        distance = self.object.v_x * 1.1  # > self.v_x
+        wall_right = self.make_wall(x=distance)
+        
+        gameboard = GameBoard([wall_right], [], [], [])
+
+        self.object.move_x(gameboard)
+        self.assertEqual(
+            self.object.rect.x,
+            self.object.v_x)
+
+    def test_calls_handler_on_collision(self):
+        distance = self.object.v_x * 0.1  # < self.v_x
+        wall_right = self.make_wall(x=distance)
+        
+        gameboard = GameBoard([wall_right], [], [], [])
+
+        expected_direction = 'R'
+        expected_location = Point(
+            self.base_rect.width + distance - 1,
+            0)
+
+        with mock.patch.object(self.object, 'on_collision') as mock_collision:
+            self.object.move_x(gameboard)
+            mock_collision.assert_called_once_with(
+                direction=expected_direction,
+                location=expected_location)

--- a/tests/test_moving_object.py
+++ b/tests/test_moving_object.py
@@ -1,28 +1,27 @@
-import pygame
 from unittest import TestCase, mock
 
-from silnik import image
+from silnik.image import Image
 from silnik.rendering.point import Point
+from silnik.rendering.shape import rectangle
 
 from bounce.gameboard import GameBoard
 from bounce.game_object import GameObject
 from bounce.moving_object import MovingObject
-from bounce import image_paths
 
 class TestMovingObject(TestCase):
     """
     Base TestCase to share the setup logic and data
     """
     def setUp(self):
-        size = width, height = (1280, 720)
-        screen = pygame.display.set_mode(size)  # FIXME: decouple GameObject from pygame.display
-        img = image.Image.load(image_paths.PLAYER_MAIN)  # some image is needed to construct an GameObject
-        
+        shape = rectangle(
+            Point(0, 0),
+            Point(100, 100))
+        img = Image("mock_raw_image", shape)
         self.object = MovingObject(img)
         self.base_rect = self.object.rect
 
     def make_wall(self, x=0, y=0):
-        img = image.Image.create(self.base_rect.clone())
+        img = Image.create(self.base_rect.clone())
         return GameObject(
             img,
             x=x + self.base_rect.width,

--- a/tests/test_moving_object.py
+++ b/tests/test_moving_object.py
@@ -54,8 +54,6 @@ class TestMove(TestMovingObject):
             self.base_rect.width + distance - 1,
             0)
 
-        with mock.patch.object(self.object, 'on_collision') as mock_collision:
+        with mock.patch.object(self.object, 'on_collision_x') as mock_collision:
             self.object.move_x(gameboard)
-            mock_collision.assert_called_once_with(
-                direction=expected_direction,
-                location=expected_location)
+            mock_collision.assert_called_once_with(wall_right)


### PR DESCRIPTION
Główna część logiki do obsługi kolizji a priori. (#4)

Chwilowo wyłączyłem detekcję kolizji dla kul - dzięki temu gra się nie rzuca, ale kule są bezużyteczne. Kolizje kul trzeba przepisać z użyciem `MovingObject`.